### PR TITLE
Fix strategy validation bugs in Multi-Timeframe and Volatility Sizing

### DIFF
--- a/strategies/multi_timeframe_strategy.py
+++ b/strategies/multi_timeframe_strategy.py
@@ -96,15 +96,16 @@ def analyze_multi_timeframe_strategy(timeframe_data: Dict, current_price: float)
             raise ValueError("No timeframe data available for analysis")
 
     # Calculate metrics for each timeframe
+    # Convert horizon keys to strings for MongoDB compatibility
     timeframe_metrics = {}
     for horizon, (stats, df) in timeframe_data.items():
         metrics = calculate_forecast_metrics(stats, current_price, horizon)
-        timeframe_metrics[horizon] = metrics
+        timeframe_metrics[str(horizon)] = metrics  # Use string key for MongoDB
 
     # Determine bullish/bearish for each timeframe
     directions = {}
-    for horizon, metrics in timeframe_metrics.items():
-        directions[horizon] = "BULLISH" if metrics['median_change_pct'] > 0 else "BEARISH"
+    for horizon_str, metrics in timeframe_metrics.items():
+        directions[horizon_str] = "BULLISH" if metrics['median_change_pct'] > 0 else "BEARISH"
 
     # Count alignment
     bullish_count = sum(1 for d in directions.values() if d == "BULLISH")

--- a/strategies/volatility_position_sizing.py
+++ b/strategies/volatility_position_sizing.py
@@ -142,6 +142,10 @@ def analyze_volatility_position_sizing(stats_14day: Dict, current_price: float) 
     # Calculate risk amount as percentage of position
     risk_per_position = abs((stop_loss - entry_price) / entry_price) * 100
 
+    # Extract confidence as a single float value (use prediction_cv as the confidence metric)
+    # Lower CV = higher confidence
+    confidence_value = 100.0 - min(confidence.get('prediction_cv', 0), 100.0)
+
     strategy_data = {
         'signal': signal,
         'volatility_level': volatility_level,
@@ -161,7 +165,8 @@ def analyze_volatility_position_sizing(stats_14day: Dict, current_price: float) 
         'avg_loss': avg_loss,
         'current_price': current_price,
         'metrics': metrics,
-        'confidence': confidence,
+        'confidence': confidence_value,  # Single float value instead of dict
+        'confidence_metrics': confidence,  # Full confidence dict in metadata
     }
 
     return strategy_data


### PR DESCRIPTION
## Summary

Fixed two critical bugs that were causing strategy failures during consensus analysis:

### 1. Multi-Timeframe Strategy (MongoDB Key Type Error)
**File**: `strategies/multi_timeframe_strategy.py`

**Problem**: MongoDB validation error - "documents must have only string keys, key was 14"

**Root Cause**: Dictionary keys used integer horizon values (3, 7, 14, 21) but MongoDB requires all dictionary keys to be strings.

**Fix**: Convert horizon keys to strings using `str(horizon)` when building `timeframe_metrics` and `directions` dictionaries.

```python
# Before
timeframe_metrics[horizon] = metrics  # horizon is int

# After  
timeframe_metrics[str(horizon)] = metrics  # horizon converted to string
```

### 2. Volatility Sizing Strategy (Pydantic Type Validation Error)
**File**: `strategies/volatility_position_sizing.py`

**Problem**: Pydantic validation error - "confidence Input should be a valid number, got dict"

**Root Cause**: The `confidence` field in `StrategySignal` expects a float value, but the code was passing an entire dictionary containing metrics like `{'pct_above': 20.0, 'pct_below': 25.0, 'prediction_cv': 4.62}`.

**Fix**: Extract a single float value from the confidence dictionary and store the full dict in metadata:

```python
# Extract single confidence value (lower CV = higher confidence)
confidence_value = 100.0 - min(confidence.get('prediction_cv', 0), 100.0)

strategy_data = {
    'confidence': confidence_value,  # Single float for validation
    'confidence_metrics': confidence,  # Full dict in metadata
}
```

## Testing

Verified both fixes with a live consensus analysis on BTC-USD:

**Before fixes** (from logs):
- ❌ `[WARNING: Multi-Timeframe failed - documents must have only string keys, key was 14]`
- ❌ `[WARNING: Volatility Sizing failed - 1 validation error for StrategySignal confidence]`

**After fixes** (from logs):
- ✅ `Multi-Timeframe completed: STRONG_SELL`
- ✅ `Volatility Sizing completed: STAY_OUT_BEARISH`

All 8 strategies now complete successfully without warnings. Analysis completed in 27.7 seconds.

## Impact

- Fixes critical consensus analysis bugs that were causing 2 out of 8 strategies to fail
- Ensures all strategies can contribute to consensus calculations
- Improves system reliability and data integrity

## Files Changed

- `strategies/multi_timeframe_strategy.py` (+3/-2 lines)
- `strategies/volatility_position_sizing.py` (+5/-1 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)