### PR TITLE
Fix S3 ticker format mapping for Massive.com flat files

### DIFF
--- a/strategies/massive_s3_data_source.py
+++ b/strategies/massive_s3_data_source.py
@@ -88,14 +88,15 @@ class MassiveS3DataSource:
             symbol: Symbol like 'BTC-USD', 'ETH-USD'
 
         Returns:
-            Massive.com compatible symbol (e.g., 'BTC', 'ETH')
+            Massive.com compatible symbol (e.g., 'X:BTC-USD', 'X:ETH-USD')
         """
-        # Convert crypto symbols
+        # Convert crypto symbols - Massive.com uses X: prefix for crypto
         if '-USD' in symbol:
-            # BTC-USD -> BTC
-            return symbol.replace('-USD', '')
+            # BTC-USD -> X:BTC-USD
+            return f'X:{symbol}'
         else:
-            return symbol
+            # If no suffix, assume USD and add it
+            return f'X:{symbol}-USD'
 
     def _list_available_files(self, prefix: str, start_date: datetime, end_date: datetime) -> list:
         """


### PR DESCRIPTION
## Problem
- S3 CSV files from Massive.com use ticker format `X:BTC-USD` (with `X:` prefix)
- Previous code converted `BTC-USD` → `BTC` and searched for `BTC` in CSV files
- Result: 729 S3 files downloaded but **no data found for ticker**
- System fell back to REST API which only provided **131 days** of data

## Root Cause
After inspecting actual S3 CSV files, discovered ticker column contains values like:
- `X:BTC-USD` (not `BTC`)
- `X:ETH-USD` (not `ETH`)
- `X:AAVE-USD`, etc.

The `X:` prefix is Massive.com's format for crypto tickers.

## Solution
Updated `strategies/massive_s3_data_source.py`:
- Changed `_get_ticker_symbol()` method
- Now adds `X:` prefix instead of removing `-USD` suffix
- Converts `BTC-USD` → `X:BTC-USD` to match S3 CSV format

## Testing Results
✅ Successfully retrieves **729 days (2 years)** of historical data from S3  
✅ Logs confirm: `✓ Fetched 729 rows for BTC-USD from S3 flat files`  
✅ Logs confirm: `✓ Using S3 flat files for BTC-USD`  
✅ **Massive improvement** from 131 days (REST API) to 729 days (S3)

## Changed Files
- `strategies/massive_s3_data_source.py`: Updated ticker conversion logic

## Impact
- Provides **5.5x more historical data** (729 days vs 131 days)
- Enables better forecasting with 2 years of price history
- Reduces load on Polygon.io REST API (rate-limited)
- Utilizes paid S3 flat files subscription effectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)