### PR TITLE
Fix historical data period for ensemble predictions

### DIFF
--- a/examples/crypto_ensemble_forecast.py
+++ b/examples/crypto_ensemble_forecast.py
@@ -190,8 +190,8 @@ def make_ensemble_predictions(ensemble_models, symbol, forecast_horizon=7):
     prediction_details = []
 
     for model_info in ensemble_models:
-        # Fetch latest data
-        df_latest = fetch_crypto_data(symbol, period='6mo')
+        # Fetch latest data - use 2 years to match training data and enable saving full history
+        df_latest = fetch_crypto_data(symbol, period='2y')
         df_latest, _ = add_technical_indicators(df_latest, focus=model_info['focus'])
 
         # Prepare features


### PR DESCRIPTION
## Problem
- UI chart only showed ~130 days of historical data
- MongoDB only had 130 days saved
- S3 was successfully fetching 729 days for training
- But historical data wasn't being saved to MongoDB

## Root Cause
Found in `examples/crypto_ensemble_forecast.py:194`:
- Training fetched **2 years** of data (`period='2y'`) from S3 ✅
- Prediction generation fetched only **6 months** (`period='6mo'`) 
- The 6-month DataFrame was returned from `train_ensemble()`
- Only this limited DataFrame got saved to MongoDB via `save_historical_prices()`
- The full 729-day training data was never saved

## Solution
Changed `make_ensemble_predictions()` to use `period='2y'`:
```python
# Before:
df_latest = fetch_crypto_data(symbol, period='6mo')

# After:
df_latest = fetch_crypto_data(symbol, period='2y')
```

Now the same 2-year data period is used for both training AND prediction generation, ensuring the full DataFrame gets saved to MongoDB.

## Testing Results
✅ MongoDB now has **679 days** of historical data (vs 130 days before)  
✅ Date range: **2023-12-22 to 2025-10-30** (~1.9 years)  
✅ **5.2x improvement** in historical data availability  
✅ UI chart can now display nearly 2 years of price history  

## Impact
- Better chart visualization with extended historical context
- More meaningful historical price analysis for users
- Consistent data period between training and predictions
- Full utilization of S3 flat files historical data

## Changed Files
- `examples/crypto_ensemble_forecast.py`: Changed period from '6mo' to '2y'

🤖 Generated with [Claude Code](https://claude.com/claude-code)