### PR TITLE
Change license to AGPLv3 with Contributor Assignment Agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Temporal Trading Agents
+
+Thank you for your interest in contributing to this project!
+
+## Contributor Assignment Agreement (CAA)
+
+Before we can accept your contributions, you must sign a Contributor Assignment Agreement (CAA). This agreement assigns copyright of your contributions to Unidatum Integrated Products LLC while granting you a perpetual license to use your contributions.
+
+### Why a CAA?
+
+The CAA allows us to:
+- Maintain clear ownership of the codebase
+- Enforce the AGPLv3 license effectively
+- Protect the project and its users legally
+- Make future licensing decisions if needed
+
+### How to Sign the CAA
+
+1. Download the CAA template: [CONTRIBUTOR_AGREEMENT.md](./CONTRIBUTOR_AGREEMENT.md)
+2. Fill in your information
+3. Sign and date the agreement
+4. Email the signed agreement to: legal@unidatum.com
+
+Alternatively, for electronic signatures:
+- Send an email from your primary email address to legal@unidatum.com with the subject "CAA Agreement - [Your Name]" and include the filled-out agreement in the body
+
+### First-time Contributors
+
+Include the following statement in your first pull request:
+
+```
+I have read and agree to the Contributor Assignment Agreement (CAA) and
+have submitted my signed agreement to legal@unidatum.com.
+```
+
+### Code of Conduct
+
+- Write clear, maintainable code
+- Follow existing code style and conventions
+- Include tests for new features
+- Update documentation as needed
+- Be respectful and professional in all interactions
+
+### Development Setup
+
+See [README.md](./README.md) for instructions on setting up your development environment.
+
+### Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Make your changes
+4. Write or update tests
+5. Ensure all tests pass
+6. Commit your changes with clear commit messages
+7. Push to your fork
+8. Open a Pull Request
+
+### Questions?
+
+If you have questions about the CAA or contribution process, please contact us at legal@unidatum.com

--- a/CONTRIBUTOR_AGREEMENT.md
+++ b/CONTRIBUTOR_AGREEMENT.md
@@ -1,0 +1,98 @@
+# Contributor Assignment Agreement
+
+**Temporal Trading Agents Project**
+
+This Contributor Assignment Agreement ("Agreement") is entered into between:
+
+**Contributor Information:**
+- Full Legal Name: _________________________________
+- Email Address: _________________________________
+- GitHub Username: _________________________________
+- Date: _________________________________
+
+**AND**
+
+**Unidatum Integrated Products LLC** ("Company")
+- Address: _________________________________
+- Email: legal@unidatum.com
+
+## 1. Assignment of Copyright
+
+The Contributor hereby assigns to the Company all right, title, and interest throughout the world in and to all copyrights in any contributions made by the Contributor to the Temporal Trading Agents project (the "Contributions").
+
+This includes, but is not limited to:
+- Source code
+- Documentation
+- Bug fixes
+- Feature additions
+- Tests
+- Configuration files
+- Any other materials submitted to the project
+
+## 2. License Grant Back to Contributor
+
+The Company hereby grants to the Contributor a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license under the assigned copyrights to use, reproduce, modify, display, perform, sublicense, and distribute the Contributions as part of the Temporal Trading Agents project or independently.
+
+## 3. Representations and Warranties
+
+The Contributor represents and warrants that:
+
+a) The Contributor is the original author of all Contributions and has the legal right to assign the copyrights.
+
+b) The Contributions do not infringe upon any third-party intellectual property rights.
+
+c) If the Contributor is employed, the Contributor has received permission from their employer to make the Contributions, or the Contributions are made outside the scope of employment.
+
+d) The Contributions are submitted voluntarily and without any expectation of compensation.
+
+## 4. Patent Notice
+
+The Contributor acknowledges that the Temporal Trading Agents project incorporates the temporal-forecasting library, which implements technology subject to a pending patent application:
+
+**"Transformer-based Time Series Forecasting System and Method"**
+US Patent Application No. 63/910,189
+Filed: November 3, 2025
+
+## 5. Governing License
+
+The Contributor agrees that all Contributions will be licensed under the GNU Affero General Public License v3.0 (AGPLv3) or any later version as determined by the Company.
+
+## 6. Effective Date
+
+This Agreement is effective as of the date first written above and applies to all past, present, and future Contributions made by the Contributor to the project.
+
+---
+
+## Signature
+
+By signing below, the Contributor agrees to the terms of this Contributor Assignment Agreement:
+
+**Contributor Signature:**
+
+Signature: _________________________________
+
+Print Name: _________________________________
+
+Date: _________________________________
+
+---
+
+**For Electronic Signatures:**
+
+If signing electronically, send an email from your primary email address to legal@unidatum.com with the subject "CAA Agreement - [Your Name]" and include this completed form in the email body with the statement:
+
+"I, [Full Name], hereby agree to the terms of the Contributor Assignment Agreement dated [Date]."
+
+---
+
+**Company Use Only:**
+
+Accepted by Unidatum Integrated Products LLC:
+
+Signature: _________________________________
+
+Name: _________________________________
+
+Title: _________________________________
+
+Date: _________________________________

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,34 @@
-MIT License
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
 
-Copyright (c) 2025 Unidatum Integrated Products LLC
+Copyright (C) 2025 Unidatum Integrated Products LLC
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+ADDITIONAL TERMS
+
+Contributors must sign a Contributor Assignment Agreement (CAA).
+See CONTRIBUTING.md for details.
+
+PATENT NOTICE
+
+This software incorporates the temporal-forecasting library, which implements
+technology that is the subject of a pending patent application:
+
+"Transformer-based Time Series Forecasting System and Method"
+US Patent Application No. 63/910,189
+Filed: November 3, 2025
+
+The full text of the GNU Affero General Public License Version 3 can be found at:
+https://www.gnu.org/licenses/agpl-3.0.txt

--- a/README.md
+++ b/README.md
@@ -1343,14 +1343,17 @@ docker-compose up
 
 Contributions are welcome! Whether it's bug fixes, new strategies, improved documentation, or feature requests, we appreciate your help.
 
+**Important:** All contributors must sign a Contributor Assignment Agreement (CAA) before their contributions can be accepted. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+
 ### How to Contribute
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/my-new-feature`
-3. Make your changes with clear commit messages
-4. Write tests if applicable
-5. Update documentation as needed
-6. Submit a pull request
+1. Review the [Contributor Assignment Agreement](./CONTRIBUTOR_AGREEMENT.md)
+2. Fork the repository
+3. Create a feature branch: `git checkout -b feature/my-new-feature`
+4. Make your changes with clear commit messages
+5. Write tests if applicable
+6. Update documentation as needed
+7. Submit a pull request (include CAA acknowledgment in your first PR)
 
 ### Development Setup
 
@@ -1372,7 +1375,23 @@ npm test
 
 ## License
 
-See LICENSE file for details.
+This project is licensed under the **GNU Affero General Public License v3.0 (AGPLv3)**.
+
+Copyright (C) 2025 Unidatum Integrated Products LLC
+
+See the [LICENSE](./LICENSE) file for the full license text.
+
+### Patent Notice
+
+This software incorporates the [temporal-forecasting](https://github.com/OptimalMatch/temporal) library, which implements technology that is the subject of a pending patent application:
+
+**"Transformer-based Time Series Forecasting System and Method"**
+US Patent Application No. 63/910,189
+Filed: November 3, 2025
+
+### Contributor Assignment Agreement
+
+All contributors must sign a Contributor Assignment Agreement (CAA) before their contributions can be accepted. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
 ---
 


### PR DESCRIPTION
## Summary

- Changed license from MIT to AGPLv3
- Added Contributor Assignment Agreement (CAA) requirement for all contributors
- Included patent notice for temporal-forecasting library (US Patent Application No. 63/910,189)

## Changes

### LICENSE
- Replaced MIT license with AGPLv3 notice
- Added copyright notice: Unidatum Integrated Products LLC
- Included CAA requirement reference
- Added patent notice for transformer-based time series forecasting technology

### CONTRIBUTING.md (new)
- Comprehensive contributor guidelines
- CAA requirements and rationale
- Instructions for signing the agreement (email to legal@unidatum.com)
- Development setup and submission process

### CONTRIBUTOR_AGREEMENT.md (new)
- Full copyright assignment agreement template
- License grant back to contributors
- Representations and warranties
- Patent acknowledgment
- Electronic signature instructions

### README.md
- Updated Contributing section with CAA requirements
- Enhanced License section with AGPLv3 details and patent notice
- Added links to CONTRIBUTING.md and CONTRIBUTOR_AGREEMENT.md