### PR TITLE
Add experiment framework for A/B testing paper trading strategies

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -744,6 +744,29 @@ class SignalLog(BaseModel):
         return dt.isoformat().replace('+00:00', 'Z')
 
 
+class Experiment(BaseModel):
+    """Experiment for comparing paper trading strategies"""
+    experiment_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    name: str
+    description: str
+    symbol: str  # Symbol being tested (e.g., BTC-USD)
+    parameter_tested: str  # What parameter is being tested (e.g., "min_edge_bps")
+    status: str = "active"  # active, completed, archived
+    session_ids: List[str] = []  # List of session IDs in this experiment
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    completed_at: Optional[datetime] = None
+    metadata: Dict[str, Any] = {}  # Additional metadata
+
+    @field_serializer('created_at', 'completed_at')
+    def serialize_datetime(self, dt: Optional[datetime], _info):
+        """Serialize datetime with timezone"""
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat().replace('+00:00', 'Z')
+
+
 class PaperTradingSession(BaseModel):
     """Paper trading session"""
     session_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -766,6 +789,7 @@ class PaperTradingSession(BaseModel):
     started_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     stopped_at: Optional[datetime] = None
     error_message: Optional[str] = None
+    experiment_group: Optional[str] = None  # ID of experiment this session belongs to
 
     @field_serializer('last_signal_check', 'next_signal_check', 'started_at', 'stopped_at')
     def serialize_datetime(self, dt: Optional[datetime], _info):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter as Router, Routes, Route, Link, useLocation } from 'react-router-dom';
-import { Activity, Calendar, History, Play, TrendingUp, Database, BarChart3, Settings, Info, Zap, Clock } from 'lucide-react';
+import { Activity, Calendar, History, Play, TrendingUp, Database, BarChart3, Settings, Info, Zap, Clock, Target } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import Dashboard from './pages/Dashboard';
 import HistoryPage from './pages/HistoryPage';
@@ -9,6 +9,7 @@ import DataSyncPage from './pages/DataSyncPage';
 import BacktestPage from './pages/BacktestPage';
 import OptimizationPage from './pages/OptimizationPage';
 import PaperTradingPage from './pages/PaperTradingPage';
+import ExperimentsPage from './pages/ExperimentsPage';
 import AboutPage from './pages/AboutPage';
 
 function Navigation() {
@@ -29,6 +30,7 @@ function Navigation() {
     { path: '/backtest', label: 'Backtest', icon: BarChart3 },
     { path: '/optimize', label: 'Optimize', icon: Settings },
     { path: '/paper', label: 'Paper', icon: Zap },
+    { path: '/experiments', label: 'Experiments', icon: Target },
     { path: '/history', label: 'History', icon: History },
     { path: '/scheduler', label: 'Scheduler', icon: Calendar },
     { path: '/data-sync', label: 'Data', icon: Database },
@@ -111,6 +113,7 @@ function App() {
             <Route path="/backtest" element={<BacktestPage />} />
             <Route path="/optimize" element={<OptimizationPage />} />
             <Route path="/paper" element={<PaperTradingPage />} />
+            <Route path="/experiments" element={<ExperimentsPage />} />
             <Route path="/history" element={<HistoryPage />} />
             <Route path="/scheduler" element={<SchedulerPage />} />
             <Route path="/data-sync" element={<DataSyncPage />} />

--- a/frontend/src/pages/ExperimentsPage.jsx
+++ b/frontend/src/pages/ExperimentsPage.jsx
@@ -1,0 +1,506 @@
+import { useState, useEffect } from 'react';
+import { Target, Plus, TrendingUp, TrendingDown, Trash2, CheckCircle, Eye, BarChart3 } from 'lucide-react';
+
+const API_BASE = '/api/v1';
+
+export default function ExperimentsPage() {
+  const [experiments, setExperiments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedExperiment, setSelectedExperiment] = useState(null);
+  const [comparisonData, setComparisonData] = useState(null);
+  const [loadingComparison, setLoadingComparison] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    symbol: 'BTC-USD',
+    parameter_tested: 'min_edge_bps'
+  });
+
+  useEffect(() => {
+    loadExperiments();
+  }, []);
+
+  const loadExperiments = async () => {
+    try {
+      const response = await fetch(`${API_BASE}/experiments`);
+      const data = await response.json();
+      setExperiments(data);
+    } catch (error) {
+      console.error('Failed to load experiments:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateExperiment = async (e) => {
+    e.preventDefault();
+
+    try {
+      const response = await fetch(
+        `${API_BASE}/experiments?name=${encodeURIComponent(formData.name)}&description=${encodeURIComponent(formData.description)}&symbol=${formData.symbol}&parameter_tested=${formData.parameter_tested}`,
+        { method: 'POST' }
+      );
+
+      if (response.ok) {
+        setShowCreateForm(false);
+        setFormData({
+          name: '',
+          description: '',
+          symbol: 'BTC-USD',
+          parameter_tested: 'min_edge_bps'
+        });
+        loadExperiments();
+      } else {
+        alert('Failed to create experiment');
+      }
+    } catch (error) {
+      console.error('Error creating experiment:', error);
+      alert('Error creating experiment');
+    }
+  };
+
+  const completeExperiment = async (experimentId) => {
+    if (!confirm('Mark this experiment as completed?')) return;
+
+    try {
+      const response = await fetch(`${API_BASE}/experiments/${experimentId}/complete`, {
+        method: 'POST'
+      });
+
+      if (response.ok) {
+        loadExperiments();
+      }
+    } catch (error) {
+      console.error('Error completing experiment:', error);
+    }
+  };
+
+  const deleteExperiment = async (experimentId) => {
+    if (!confirm('Delete this experiment? (Sessions will not be deleted)')) return;
+
+    try {
+      const response = await fetch(`${API_BASE}/experiments/${experimentId}`, {
+        method: 'DELETE'
+      });
+
+      if (response.ok) {
+        loadExperiments();
+        if (selectedExperiment?.experiment_id === experimentId) {
+          setSelectedExperiment(null);
+          setComparisonData(null);
+        }
+      }
+    } catch (error) {
+      console.error('Error deleting experiment:', error);
+    }
+  };
+
+  const viewComparison = async (experiment) => {
+    setSelectedExperiment(experiment);
+    setLoadingComparison(true);
+
+    try {
+      const response = await fetch(`${API_BASE}/experiments/${experiment.experiment_id}/compare`);
+      const data = await response.json();
+      setComparisonData(data);
+    } catch (error) {
+      console.error('Error loading comparison:', error);
+      alert('Failed to load comparison data');
+    } finally {
+      setLoadingComparison(false);
+    }
+  };
+
+  const formatDateTime = (dateStr) => {
+    if (!dateStr) return 'N/A';
+    const date = new Date(dateStr);
+    return date.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  const formatNumber = (num, decimals = 2) => {
+    if (num === undefined || num === null) return 'N/A';
+    return num.toFixed(decimals);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-gray-400">Loading experiments...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <Target className="w-8 h-8 text-purple-400" />
+          <h1 className="text-3xl font-bold text-gray-100">Experiments</h1>
+        </div>
+        <button
+          onClick={() => setShowCreateForm(true)}
+          className="flex items-center space-x-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+        >
+          <Plus className="w-5 h-5" />
+          <span>New Experiment</span>
+        </button>
+      </div>
+
+      {/* Create Experiment Modal */}
+      {showCreateForm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-800 rounded-lg max-w-2xl w-full border border-gray-700">
+            <div className="p-6">
+              <h2 className="text-2xl font-bold text-gray-100 mb-4">Create New Experiment</h2>
+
+              <form onSubmit={handleCreateExperiment} className="space-y-4">
+                {/* Experiment Name */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-1">
+                    Experiment Name *
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                    placeholder="BTC Min Edge Comparison"
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    required
+                  />
+                </div>
+
+                {/* Description */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-1">
+                    Description *
+                  </label>
+                  <textarea
+                    value={formData.description}
+                    onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                    placeholder="Compare different minimum edge thresholds for BTC-USD trading..."
+                    rows="3"
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    required
+                  />
+                </div>
+
+                {/* Symbol */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-1">
+                    Symbol *
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.symbol}
+                    onChange={(e) => setFormData({ ...formData, symbol: e.target.value })}
+                    placeholder="BTC-USD"
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    required
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    The trading symbol this experiment will test
+                  </p>
+                </div>
+
+                {/* Parameter Being Tested */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-1">
+                    Parameter Being Tested *
+                  </label>
+                  <select
+                    value={formData.parameter_tested}
+                    onChange={(e) => setFormData({ ...formData, parameter_tested: e.target.value })}
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    required
+                  >
+                    <option value="min_edge_bps">Minimum Edge (bps)</option>
+                    <option value="position_size_pct">Position Size (%)</option>
+                    <option value="check_interval_minutes">Check Interval (minutes)</option>
+                    <option value="other">Other</option>
+                  </select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    The strategy parameter you want to A/B test
+                  </p>
+                </div>
+
+                {/* Actions */}
+                <div className="flex items-center justify-end space-x-3 pt-4">
+                  <button
+                    type="button"
+                    onClick={() => setShowCreateForm(false)}
+                    className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+                  >
+                    Create Experiment
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Experiments List */}
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-gray-750">
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Name
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Symbol
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Parameter
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Sessions
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Created
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700">
+              {experiments.length === 0 ? (
+                <tr>
+                  <td colSpan="7" className="px-6 py-8 text-center text-gray-500">
+                    No experiments yet. Create one to start A/B testing your strategies.
+                  </td>
+                </tr>
+              ) : (
+                experiments.map((exp) => (
+                  <tr key={exp.experiment_id} className="hover:bg-gray-750">
+                    <td className="px-6 py-4 text-sm text-gray-300">
+                      <div>
+                        <div className="font-semibold">{exp.name}</div>
+                        <div className="text-xs text-gray-500">{exp.description}</div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-300">
+                      <span className="font-mono">{exp.symbol}</span>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-300">
+                      {exp.parameter_tested}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-300">
+                      <span className="font-semibold">{exp.session_ids.length}</span>
+                    </td>
+                    <td className="px-6 py-4 text-sm">
+                      <span
+                        className={`px-2 py-1 rounded text-xs font-medium ${
+                          exp.status === 'active'
+                            ? 'bg-green-900/50 text-green-400'
+                            : 'bg-gray-700 text-gray-400'
+                        }`}
+                      >
+                        {exp.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-400">
+                      {formatDateTime(exp.created_at)}
+                    </td>
+                    <td className="px-6 py-4 text-sm">
+                      <div className="flex items-center space-x-2">
+                        <button
+                          onClick={() => viewComparison(exp)}
+                          className="p-2 hover:bg-purple-900/50 rounded border border-purple-700/50"
+                          title="View Comparison"
+                        >
+                          <Eye className="w-4 h-4 text-purple-400" />
+                        </button>
+                        {exp.status === 'active' && (
+                          <button
+                            onClick={() => completeExperiment(exp.experiment_id)}
+                            className="p-2 hover:bg-green-900/50 rounded border border-green-700/50"
+                            title="Mark Complete"
+                          >
+                            <CheckCircle className="w-4 h-4 text-green-400" />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => deleteExperiment(exp.experiment_id)}
+                          className="p-2 hover:bg-red-900/50 rounded border border-red-700/50"
+                          title="Delete"
+                        >
+                          <Trash2 className="w-4 h-4 text-red-400" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Comparison View */}
+      {selectedExperiment && (
+        <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-700 flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <BarChart3 className="w-6 h-6 text-purple-400" />
+              <div>
+                <h2 className="text-xl font-bold text-gray-100">{selectedExperiment.name}</h2>
+                <p className="text-sm text-gray-400">{selectedExperiment.description}</p>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                setSelectedExperiment(null);
+                setComparisonData(null);
+              }}
+              className="text-gray-400 hover:text-gray-300"
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="p-6">
+            {loadingComparison ? (
+              <div className="text-center text-gray-400 py-8">Loading comparison data...</div>
+            ) : comparisonData ? (
+              <div className="space-y-6">
+                {/* Summary Cards */}
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="bg-gray-750 rounded-lg p-4 border border-gray-700">
+                    <p className="text-xs text-gray-400 mb-1">Total Sessions</p>
+                    <p className="text-2xl font-bold text-gray-100">
+                      {comparisonData.summary.total_sessions}
+                    </p>
+                  </div>
+                  <div className="bg-gray-750 rounded-lg p-4 border border-gray-700">
+                    <p className="text-xs text-gray-400 mb-1">Best P&L Session</p>
+                    <p className="text-sm font-mono text-green-400">
+                      {comparisonData.summary.best_pnl_session?.substring(0, 8) || 'N/A'}
+                    </p>
+                  </div>
+                </div>
+
+                {/* Comparison Table */}
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="bg-gray-750">
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Session</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Min Edge (bps)</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">P&L</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">P&L %</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Total Trades</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Win/Loss</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Win Rate</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Max DD</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-400">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-700">
+                      {comparisonData.sessions.length === 0 ? (
+                        <tr>
+                          <td colSpan="9" className="px-4 py-8 text-center text-gray-500">
+                            No sessions in this experiment yet.
+                          </td>
+                        </tr>
+                      ) : (
+                        comparisonData.sessions.map((session) => {
+                          const isBestPnl = session.session_id === comparisonData.summary.best_pnl_session;
+
+                          return (
+                            <tr
+                              key={session.session_id}
+                              className={`hover:bg-gray-750 ${
+                                isBestPnl ? 'bg-purple-900/20' : ''
+                              }`}
+                            >
+                              <td className="px-4 py-3 text-xs">
+                                <div>
+                                  <div className="font-mono text-gray-300">
+                                    {session.session_id.substring(0, 8)}
+                                  </div>
+                                  <div className="text-gray-500">{session.name}</div>
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 text-sm text-blue-400 font-semibold">
+                                {session.min_edge_bps}
+                              </td>
+                              <td className="px-4 py-3 text-sm">
+                                <span
+                                  className={
+                                    session.total_pnl >= 0 ? 'text-green-400' : 'text-red-400'
+                                  }
+                                >
+                                  ${formatNumber(session.total_pnl)}
+                                  {isBestPnl && ' 🏆'}
+                                </span>
+                              </td>
+                              <td className="px-4 py-3 text-sm">
+                                <span
+                                  className={
+                                    session.total_pnl_pct >= 0 ? 'text-green-400' : 'text-red-400'
+                                  }
+                                >
+                                  {formatNumber(session.total_pnl_pct)}%
+                                </span>
+                              </td>
+                              <td className="px-4 py-3 text-sm text-gray-300">
+                                {session.total_trades}
+                              </td>
+                              <td className="px-4 py-3 text-sm">
+                                <span className="text-green-400">{session.winning_trades || 0}</span>
+                                <span className="text-gray-500"> / </span>
+                                <span className="text-red-400">{session.losing_trades || 0}</span>
+                              </td>
+                              <td className="px-4 py-3 text-sm text-gray-300">
+                                {formatNumber(session.win_rate)}%
+                              </td>
+                              <td className="px-4 py-3 text-sm text-orange-400">
+                                {formatNumber(session.max_drawdown)}%
+                              </td>
+                              <td className="px-4 py-3 text-xs">
+                                <span
+                                  className={`px-2 py-1 rounded ${
+                                    session.status === 'active'
+                                      ? 'bg-green-900/50 text-green-400'
+                                      : 'bg-gray-700 text-gray-400'
+                                  }`}
+                                >
+                                  {session.status}
+                                </span>
+                              </td>
+                            </tr>
+                          );
+                        })
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : (
+              <div className="text-center text-gray-400 py-8">No comparison data available</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements a comprehensive experiment framework for A/B testing paper trading strategies, enabling systematic comparison of different parameter values (e.g., min_edge_bps) on the same symbol.

## Changes

### Backend
- **Models** (`backend/models.py`):
  - Added `Experiment` model with fields for experiment metadata, session tracking, and status
  - Added `experiment_group` field to `PaperTradingSession` for linking sessions to experiments

- **Database** (`backend/database.py`):
  - Added CRUD operations for experiments: `store_experiment`, `get_experiment`, `get_experiments`, `update_experiment`, `delete_experiment`

- **API Endpoints** (`backend/main.py`):
  - `POST /api/v1/experiments` - Create new experiment
  - `GET /api/v1/experiments` - List experiments with optional filters
  - `GET /api/v1/experiments/{id}` - Get experiment details
  - `POST /api/v1/experiments/{id}/add-session` - Add session to experiment
  - `POST /api/v1/experiments/{id}/complete` - Mark experiment complete
  - `GET /api/v1/experiments/{id}/compare` - Compare session metrics
  - `DELETE /api/v1/experiments/{id}` - Delete experiment

- **Comparison Logic**:
  - Calculates win rate, max drawdown
  - Uses session-level aggregated metrics (winning_trades, losing_trades)
  - Identifies best performing sessions

### Frontend
- **Experiments Page** (`frontend/src/pages/ExperimentsPage.jsx`):
  - Modal form for creating experiments (name, description, symbol, parameter)
  - Experiment list table with status and session counts
  - Comparison view with metrics table and summary cards
  - Trophy indicators for best P&L sessions
  - Actions: view comparison, mark complete, delete

- **Paper Trading Page** (`frontend/src/pages/PaperTradingPage.jsx`):
  - Added Target icon button to assign sessions to experiments
  - Assignment modal showing active experiments
  - Experiment badge displayed on sessions
  - Experiment dropdown in session creation form

- **Navigation** (`frontend/src/App.jsx`):
  - Added Experiments tab with Target icon

## Test Plan
- [x] Create experiment via modal form
- [x] Assign existing sessions to experiment
- [x] Create new session and assign to experiment
- [x] View comparison metrics for multiple sessions
- [x] Mark experiment as complete
- [x] Delete experiment (sessions remain)

## Usage Example
1. Navigate to Experiments page
2. Create experiment: "BTC Min Edge Comparison"
3. Go to Paper Trading, create sessions with different min_edge_bps (30, 50, 70)
4. Assign sessions to experiment or select during creation
5. View comparison to see which edge threshold performs best