### PR TITLE
Fix federation URL normalization and improve UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1553,10 +1553,17 @@ async def create_remote_instance(
 ):
     """Add a new remote instance connection"""
     try:
+        # Normalize base_url - ensure it has a protocol
+        base_url = instance_create.base_url.strip()
+        if not base_url.startswith(('http://', 'https://')):
+            base_url = f'http://{base_url}'
+        # Remove trailing slash
+        base_url = base_url.rstrip('/')
+
         # Create RemoteInstance model
         instance = RemoteInstance(
             name=instance_create.name,
-            base_url=instance_create.base_url.rstrip('/'),  # Remove trailing slash
+            base_url=base_url,
             api_key=instance_create.api_key,
             enabled=instance_create.enabled,
             status=RemoteInstanceStatus.INACTIVE
@@ -1606,7 +1613,12 @@ async def update_remote_instance(
         # Update
         update_data = instance_update.dict(exclude_unset=True)
         if update_data.get('base_url'):
-            update_data['base_url'] = update_data['base_url'].rstrip('/')
+            # Normalize base_url - ensure it has a protocol
+            base_url = update_data['base_url'].strip()
+            if not base_url.startswith(('http://', 'https://')):
+                base_url = f'http://{base_url}'
+            # Remove trailing slash
+            update_data['base_url'] = base_url.rstrip('/')
 
         success = await database.update_remote_instance(instance_id, update_data)
 

--- a/frontend/src/pages/FederationPage.jsx
+++ b/frontend/src/pages/FederationPage.jsx
@@ -204,11 +204,11 @@ function FederationPage() {
                 value={formData.base_url}
                 onChange={(e) => setFormData({ ...formData, base_url: e.target.value })}
                 className="input"
-                placeholder="http://instance2.example.com:10750"
+                placeholder="http://hostname:10750"
                 required
               />
               <p className="text-sm text-gray-500 mt-1">
-                Full URL including protocol and port
+                e.g., http://pop-os-1:10750 or http://192.168.1.100:10750
               </p>
             </div>
 


### PR DESCRIPTION
## Summary

Fixes URL normalization issues in the federation system that caused connection failures when users entered URLs without explicit protocols.

## Changes

### Backend (`backend/main.py`)
- Added automatic URL protocol normalization in `create_remote_instance` endpoint
- Added automatic URL protocol normalization in `update_remote_instance` endpoint
- Auto-prepends `http://` if protocol (`http://` or `https://`) is missing
- Prevents 503 errors from httpx when URLs lack protocol specification

### Frontend (`frontend/src/pages/FederationPage.jsx`)
- Improved base URL input field placeholder from `http://instance2.example.com:10750` to shorter `http://hostname:10750`
- Updated help text to show practical examples: `http://pop-os-1:10750` and `http://192.168.1.100:10750`
- Better UX for users entering local network instance URLs

## Problem Solved

Users were encountering this error when registering webhooks:
```
Failed to connect to remote instance: Request URL is missing an 'http://' or 'https://' protocol.
```

This occurred when entering URLs like `pop-os-1:10750` without the `http://` prefix. The httpx library requires explicit protocols, so this fix normalizes user input automatically.

## Testing

- [x] Deployed and tested with docker compose
- [x] Verified URL normalization works for both create and update operations
- [x] Confirmed backend container rebuilds and starts successfully