### PR TITLE
Add imported forecast integration to Dashboard and History pages

### DIFF
--- a/backend/forecast_publisher.py
+++ b/backend/forecast_publisher.py
@@ -246,11 +246,23 @@ def create_export_payload(consensus_result: dict) -> dict:
             "horizon_days": forecast_data.get('forecast_horizon', 14),
             "consensus": consensus_result.get('consensus', 'UNKNOWN'),
             "confidence": consensus_result.get('confidence', 0),
+            # Price forecast arrays
             "median": forecast_data.get('ensemble_median', []),
+            "ensemble_median": forecast_data.get('ensemble_median', []),
             "q25": forecast_stats.get('q25', []),
+            "ensemble_q25": forecast_stats.get('q25', []),
             "q75": forecast_stats.get('q75', []),
+            "ensemble_q75": forecast_stats.get('q75', []),
             "min": forecast_stats.get('min', []),
-            "max": forecast_stats.get('max', [])
+            "ensemble_min": forecast_stats.get('min', []),
+            "max": forecast_stats.get('max', []),
+            "ensemble_max": forecast_stats.get('max', []),
+            # Historical data for visualization
+            "historical_prices": forecast_data.get('historical_prices', []),
+            "historical_days": forecast_data.get('historical_days', 0),
+            "forecast_days": forecast_data.get('forecast_days', []),
+            "individual_models": forecast_data.get('individual_models', []),
+            "current_price": forecast_data.get('current_price')
         },
         "signals": {
             "bullish_count": consensus_result.get('bullish_count', 0),

--- a/frontend/src/components/StrategyCard.jsx
+++ b/frontend/src/components/StrategyCard.jsx
@@ -1,10 +1,11 @@
-import { TrendingUp, TrendingDown, Minus, Target, Shield } from 'lucide-react';
+import { TrendingUp, TrendingDown, Minus, Target, Shield, Network } from 'lucide-react';
 
 function StrategyCard({ consensus }) {
   if (!consensus) return null;
 
   const isBullish = consensus.consensus?.includes('BUY') || consensus.consensus?.includes('BULLISH');
   const isBearish = consensus.consensus?.includes('SELL') || consensus.consensus?.includes('AVOID');
+  const isImported = consensus.source === 'imported';
 
   return (
     <div className="space-y-4">
@@ -25,8 +26,20 @@ function StrategyCard({ consensus }) {
             </div>
           )}
           <div>
-            <h3 className="text-2xl font-bold text-gray-100">{consensus.consensus}</h3>
-            <p className="text-gray-400">Strength: {consensus.strength}</p>
+            <div className="flex items-center space-x-2">
+              <h3 className="text-2xl font-bold text-gray-100">{consensus.consensus}</h3>
+              {isImported && (
+                <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-900 text-blue-300 border border-blue-700">
+                  <Network className="w-3 h-3 mr-1" />
+                  Remote
+                </span>
+              )}
+            </div>
+            <p className="text-gray-400">
+              {isImported && consensus.remote_instance_name
+                ? `From: ${consensus.remote_instance_name}`
+                : `Strength: ${consensus.strength}`}
+            </p>
           </div>
         </div>
         <div className="text-right">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -91,8 +91,8 @@ function Dashboard() {
     try {
       setLoading(true);
 
-      // First, get the most recent consensus from any symbol
-      const allConsensus = await api.getAllConsensus(1);
+      // First, get the most recent consensus from any symbol (including imported)
+      const allConsensus = await api.getAllConsensus(1, true);
       const latestConsensus = allConsensus.results?.[0];
 
       // Determine which symbol to show analytics for

--- a/frontend/src/pages/FederationPage.jsx
+++ b/frontend/src/pages/FederationPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Plus, Server, Trash2, RefreshCw, Link2, Download, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
 import api from '../services/api';
 import { format } from 'date-fns';
+import LogsModal from '../components/LogsModal';
 
 const STATUS_COLORS = {
   active: 'text-green-600 bg-green-50',
@@ -21,6 +22,7 @@ function FederationPage() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [loading, setLoading] = useState(false);
   const [selectedTab, setSelectedTab] = useState('instances'); // 'instances' or 'forecasts'
+  const [selectedForecast, setSelectedForecast] = useState(null); // For forecast details modal
 
   // Form state
   const [formData, setFormData] = useState({
@@ -361,7 +363,11 @@ function FederationPage() {
           ) : (
             <div className="grid gap-4">
               {importedForecasts.map((forecast) => (
-                <div key={forecast.id} className="card">
+                <div
+                  key={forecast.id}
+                  className="card cursor-pointer hover:border-brand-500 transition-colors"
+                  onClick={() => setSelectedForecast(forecast)}
+                >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="flex items-center space-x-3">
@@ -405,6 +411,37 @@ function FederationPage() {
             </div>
           )}
         </div>
+      )}
+
+      {/* Forecast Details Modal */}
+      {selectedForecast && (
+        <LogsModal
+          analysis={{
+            symbol: selectedForecast.symbol,
+            strategy_type: `Imported from ${selectedForecast.remote_instance_name}`,
+            created_at: selectedForecast.remote_created_at,
+            current_price: selectedForecast.current_price,
+            forecast_data: selectedForecast.forecast_data,
+            signal: {
+              signal: selectedForecast.consensus,
+              position_size_pct: 0
+            },
+            status: 'imported',
+            execution_time_ms: null,
+            logs: [
+              `Forecast imported from remote instance: ${selectedForecast.remote_instance_name}`,
+              `Original forecast ID: ${selectedForecast.original_forecast_id}`,
+              `Imported at: ${new Date(selectedForecast.imported_at).toLocaleString()}`,
+              `Interval: ${selectedForecast.interval}`,
+              `Consensus: ${selectedForecast.consensus}`,
+              `Confidence: ${selectedForecast.confidence}%`,
+              `Signal breakdown: ${selectedForecast.signals.bullish_count} bullish, ${selectedForecast.signals.bearish_count} bearish`,
+              `Forecast horizon: ${selectedForecast.forecast_data.horizon_days} days`,
+              `Current price: $${selectedForecast.current_price.toFixed(2)}`,
+            ]
+          }}
+          onClose={() => setSelectedForecast(null)}
+        />
       )}
     </div>
   );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -69,12 +69,16 @@ class APIService {
     return this.request(`/history/analyses/${symbol}?${params}`);
   }
 
-  async getAllConsensus(limit = 100) {
-    return this.request(`/history/consensus?limit=${limit}`);
+  async getAllConsensus(limit = 100, includeImported = false) {
+    const params = new URLSearchParams({ limit: limit.toString() });
+    if (includeImported) params.append('include_imported', 'true');
+    return this.request(`/history/consensus?${params}`);
   }
 
-  async getConsensusHistory(symbol, limit = 100) {
-    return this.request(`/history/consensus/${symbol}?limit=${limit}`);
+  async getConsensusHistory(symbol, limit = 100, includeImported = false) {
+    const params = new URLSearchParams({ limit: limit.toString() });
+    if (includeImported) params.append('include_imported', 'true');
+    return this.request(`/history/consensus/${symbol}?${params}`);
   }
 
   // Analytics


### PR DESCRIPTION
## Summary

Integrates imported forecasts from remote instances into the Dashboard and History pages, enabling users to view forecasts from federated instances alongside local forecasts.

## Changes

### Backend

**Consensus Endpoint Enhancement (`backend/main.py`)**
- Added `include_imported` parameter to `/api/v1/history/consensus` endpoints
- Merges local consensus results with imported forecasts when requested
- Implements timezone-aware datetime handling for proper sorting
- Parses ISO datetime strings from imported forecasts
- Marks all results with `source` field ('local' or 'imported')

**Export Payload Enhancement (`backend/forecast_publisher.py`)**
- Extended `create_export_payload()` to include full forecast visualization data
- Now exports: `historical_prices`, `historical_days`, `forecast_days`, `individual_models`
- Supports both naming conventions: `median`/`ensemble_median` for compatibility

### Frontend

**Dashboard, History, Federation Pages**
- Integrated imported forecasts with "Remote" badges
- Added clickable detailed analysis modals
- Shows source instance attribution

**ForecastChart Component**
- Added safety checks for missing fields
- Handles both naming conventions
- Auto-generates missing arrays

## Problem Solved

- Fixed datetime comparison errors (naive vs aware, string vs datetime)
- Fixed missing historical data in imported forecast charts
- Added graceful handling of missing forecast metadata

## Features

✅ Dashboard shows imported forecasts
✅ History page lists imported with local forecasts
✅ Visual "Remote" badges with source attribution
✅ Full chart support with historical context
✅ Backward compatible

## Testing

- [x] Endpoints return merged forecasts correctly
- [x] Charts render without errors
- [x] Remote badges display properly