### PR TITLE
Use pickle cache for hourly data to avoid MongoDB 16MB limit

### DIFF
--- a/frontend/src/components/ForecastChart.jsx
+++ b/frontend/src/components/ForecastChart.jsx
@@ -12,7 +12,7 @@ import {
   ReferenceLine
 } from 'recharts';
 
-function ForecastChart({ forecastData, symbol }) {
+function ForecastChart({ forecastData, symbol, interval = '1d' }) {
   const [showIndividualModels, setShowIndividualModels] = useState(true);
   const [historicalDays, setHistoricalDays] = useState(120);
   const [extendedHistoricalData, setExtendedHistoricalData] = useState(null);
@@ -30,7 +30,9 @@ function ForecastChart({ forecastData, symbol }) {
         setLoadingHistory(true);
         try {
           // Use relative path to go through nginx proxy
-          const response = await fetch(`/api/v1/history/prices/${symbol}`);
+          // Pass interval parameter for hourly data to read from pickle cache
+          const url = `/api/v1/history/prices/${symbol}${interval ? `?interval=${interval}` : ''}`;
+          const response = await fetch(url);
           if (response.ok) {
             const data = await response.json();
             // Extract close prices from the historical data
@@ -51,7 +53,7 @@ function ForecastChart({ forecastData, symbol }) {
       // Don't need extended data, clear it
       setExtendedHistoricalData(null);
     }
-  }, [symbol, historicalDays, forecastData]);
+  }, [symbol, historicalDays, forecastData, interval]);
 
   if (!forecastData) {
     return (

--- a/frontend/src/components/LogsModal.jsx
+++ b/frontend/src/components/LogsModal.jsx
@@ -32,7 +32,11 @@ function LogsModal({ analysis, onClose }) {
           {/* Forecast Chart (if available) */}
           {analysis.forecast_data && (
             <div className="border-b border-gray-700 pb-6">
-              <ForecastChart forecastData={analysis.forecast_data} symbol={analysis.symbol} />
+              <ForecastChart
+                forecastData={analysis.forecast_data}
+                symbol={analysis.symbol}
+                interval={analysis.interval || '1d'}
+              />
             </div>
           )}
 

--- a/frontend/src/pages/AnalyzePage.jsx
+++ b/frontend/src/pages/AnalyzePage.jsx
@@ -295,7 +295,11 @@ function AnalyzePage() {
             <div className="space-y-6">
               <StrategyCard consensus={result} />
               {result.forecast_data && (
-                <ForecastChart forecastData={result.forecast_data} symbol={result.symbol} />
+                <ForecastChart
+                  forecastData={result.forecast_data}
+                  symbol={result.symbol}
+                  interval={result.interval || '1d'}
+                />
               )}
             </div>
           ) : (

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -207,7 +207,11 @@ function Dashboard() {
           <div className="space-y-6">
             <StrategyCard consensus={stats.latest_consensus} />
             {stats.latest_consensus.forecast_data && (
-              <ForecastChart forecastData={stats.latest_consensus.forecast_data} symbol={stats.latest_consensus.symbol} />
+              <ForecastChart
+                forecastData={stats.latest_consensus.forecast_data}
+                symbol={stats.latest_consensus.symbol}
+                interval={stats.latest_consensus.interval || '1d'}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

This PR addresses the MongoDB 16MB document size limit when storing large hourly datasets. Instead of saving hourly historical data to MongoDB, we now serve it directly from the pickle cache for charts and visualizations.

## Problem

When running 1h interval analysis with large datasets (e.g., BTC-USD 5y 1h):
- Pickle cache file: 121 MB (2.6M rows of minute-level data)
- Estimated MongoDB BSON size: ~200 MB
- MongoDB document limit: **16 MB** ❌
- Result: Analysis would fail when trying to save historical prices

## Solution

**Backend Changes:**
1. **Skip MongoDB save for 1h interval** (`main.py:930-935`)
   - Added conditional check: `if request.interval != '1h'`
   - Logs: "Skipping MongoDB save for 1h data (using pickle cache)"

2. **Enhanced historical prices endpoint** (`main.py:1385-1459`)
   - Added `interval` query parameter
   - When `interval=1h`: Read from pickle cache (5y period)
   - When `interval=1d`: Use MongoDB as before
   - Returns source info: `pickle_cache` or `mongodb`

**Frontend Changes:**
1. **ForecastChart.jsx** - Added `interval` prop and pass to API
2. **LogsModal.jsx** - Pass `interval` to ForecastChart
3. **Dashboard.jsx** - Pass `interval` to ForecastChart
4. **AnalyzePage.jsx** - Pass `interval` to ForecastChart

## Data Flow

### 1h Analysis (After this PR):
```
1. Analysis runs → Uses pickle cache (121MB ✅)
2. Forecast generated → Stored in consensus_results (~10KB ✅)
3. Historical prices → SKIPPED MongoDB save ✅
4. Chart needs data → Fetches from pickle cache via API ✅
```

### 1d Analysis (Unchanged):
```
1. Analysis runs → Uses pickle cache (87KB ✅)
2. Forecast generated → Stored in consensus_results (~10KB ✅)
3. Historical prices → Saved to MongoDB (~3MB ✅)
4. Chart needs data → Fetches from MongoDB ✅
```

## Testing

Tested with BTC-USD 5y 1h dataset:
- ✅ Analysis completes successfully
- ✅ No MongoDB save attempted for 1h data
- ✅ Charts display full historical context from pickle cache
- ✅ No 16MB document size errors
- ✅ 1d analysis continues working with MongoDB

## Files Changed

- `backend/main.py` (+52, -6)
- `frontend/src/components/ForecastChart.jsx` (+6, -2)
- `frontend/src/components/LogsModal.jsx` (+5, -1)
- `frontend/src/pages/AnalyzePage.jsx` (+5, -1)
- `frontend/src/pages/Dashboard.jsx` (+5, -1)

**Total: 5 files changed, 73 insertions(+), 11 deletions(-)**

## Related Issues

Resolves issue where 1h analysis would fail with MongoDB document size errors.