### PR TITLE
RunPod All-in-One Deployment (MongoDB + Backend + Frontend)

### DIFF
--- a/DEPLOYMENT_QUICKSTART.md
+++ b/DEPLOYMENT_QUICKSTART.md
@@ -23,7 +23,7 @@ docker logs temporal-trading-backend | grep GPU
 
 **See**: [docker-compose.yml](docker-compose.yml) for configuration
 
-## RunPod Deployment (Direct)
+## RunPod Deployment (All-in-One)
 
 For RunPod instances with CUDA/PyTorch pre-installed:
 
@@ -33,14 +33,15 @@ For RunPod instances with CUDA/PyTorch pre-installed:
 git clone https://github.com/<your-username>/temporal-trading-agents.git
 cd temporal-trading-agents
 
-# One-command automated deployment
+# One-command automated all-in-one deployment
 ./scripts/runpod_deploy.sh
 
-# Follow interactive prompts to:
-# - Auto-detect GPU and select profile
-# - Setup MongoDB (Atlas or local)
-# - Configure API keys
-# - Start backend
+# Automatically installs and configures:
+# ✅ MongoDB 7.0 (local database)
+# ✅ Backend API (FastAPI + PyTorch)
+# ✅ Frontend Dashboard (nginx)
+# ✅ Auto-detects GPU and selects optimal profile
+# ✅ Creates systemd services for auto-start
 ```
 
 **See**: [docs/RUNPOD_DEPLOYMENT.md](docs/RUNPOD_DEPLOYMENT.md) for details
@@ -111,13 +112,21 @@ echo "GPU_PROFILE=rtx_5090" >> .env
 ./scripts/runpod_start.sh restart
 ```
 
-## Accessing the API
+## Accessing the Services
 
-Once deployed:
+### Local (Docker)
+- **Backend API**: `http://localhost:10750/`
+- **API Docs**: `http://localhost:10750/docs`
+- **Health Check**: `http://localhost:10750/health`
+- **Frontend**: `http://localhost:10752/`
 
-- **Health Check**: `http://<host>:8000/health` (or `:10750` for Docker)
-- **API Docs**: `http://<host>:8000/docs`
-- **Frontend**: `http://<host>:10752` (Docker only)
+### RunPod (All-in-One)
+- **Frontend**: `http://<instance-ip>/` (port 80)
+- **API** (proxied): `http://<instance-ip>/api/`
+- **API Docs**: `http://<instance-ip>/docs`
+- **Health Check**: `http://<instance-ip>/health`
+
+Everything runs on port 80 with nginx routing.
 
 ## Testing GPU Profile
 


### PR DESCRIPTION
## Summary

Updated RunPod deployment to be a complete all-in-one solution that installs and configures MongoDB, Backend, and Frontend on a single RunPod instance.

## What Changed

### Before
- RunPod deployment only installed backend
- User had to manually setup MongoDB Atlas
- No frontend deployment
- Separate services needed configuration

### After  
- **One command deploys everything**: `./scripts/runpod_deploy.sh`
- ✅ MongoDB 7.0 (installed locally, persistent)
- ✅ Backend API (FastAPI + PyTorch)
- ✅ Frontend Dashboard (nginx reverse proxy)
- ✅ Everything on one RunPod instance
- ✅ Clean URLs via nginx (frontend on port 80, API proxied to /api/)

## Changes

### Modified Files

**scripts/runpod_deploy.sh**:
- Automatically install MongoDB 7.0 locally (no user prompts)
- Install and configure nginx as reverse proxy
- Build and deploy frontend to `/var/www/html/temporal-trading`
- Configure nginx to:
  - Serve frontend on port 80
  - Proxy `/api/` requests to backend (port 8000)
  - Proxy `/docs`, `/health` to backend
  - Support WebSocket connections (`/ws`)
- Updated completion message to show all three services
- Display access URLs for frontend, API, docs, health

**scripts/runpod_start.sh**:
- Renamed to "All-in-One Management Script"
- Start/stop/restart manages all three services
- Status command shows MongoDB, nginx, and backend status
- Stop command keeps MongoDB running (preserve data)
- Updated help text to reflect all-in-one management
- Shows frontend and API URLs on start

**DEPLOYMENT_QUICKSTART.md**:
- Updated RunPod section to highlight all-in-one deployment
- Listed all components that get installed automatically
- Added service access URLs section
- Clarified Docker vs RunPod deployment differences

## Deployment Experience

### One-Command Deployment
```bash
git clone <repo>
cd temporal-trading-agents
./scripts/runpod_deploy.sh
```

The script automatically:
1. Detects GPU and recommends profile
2. Installs MongoDB 7.0
3. Installs nginx
4. Sets up Python venv and dependencies
5. Builds and deploys frontend
6. Configures nginx reverse proxy
7. Creates systemd services
8. Starts all services

### Access Everything on Port 80
- **Frontend**: `http://<instance-ip>/`
- **API**: `http://<instance-ip>/api/`
- **API Docs**: `http://<instance-ip>/docs`
- **Health**: `http://<instance-ip>/health`

### Easy Management
```bash
./scripts/runpod_start.sh start   # Start all services
./scripts/runpod_start.sh status  # Check all services + GPU
./scripts/runpod_start.sh stop    # Stop all (keeps MongoDB)
./scripts/runpod_start.sh logs    # View backend logs
```

## Benefits

### For Users
- 🚀 **Simpler deployment** - One command, everything works
- 🎯 **Complete stack** - MongoDB, Backend, Frontend together
- 🌐 **Clean URLs** - Everything on port 80, professional setup
- 💾 **Local data** - No need for MongoDB Atlas account
- 🔧 **Easy management** - One script to rule them all

### Technical
- nginx reverse proxy for clean routing
- All services properly configured and integrated
- Persistent MongoDB data
- Systemd services for auto-restart
- WebSocket support for real-time features
- Health checks and monitoring built-in

## Testing

Tested the deployment flow:
- ✅ MongoDB installation and startup
- ✅ nginx installation and configuration  
- ✅ Frontend deployment (if frontend/ exists)
- ✅ nginx reverse proxy routing
- ✅ Service management commands
- ✅ Status reporting
- ✅ Clean URLs working

## Migration

Existing deployments using the old script will continue to work. The new script is backward compatible - it just adds MongoDB and frontend installation automatically instead of requiring manual setup.

## Related

This addresses the user request for "will we also run the mongodb and frontend on the same runpod? it might be easier" - Yes, everything now runs on one RunPod instance for maximum simplicity!