### PR TITLE
Fix critical normalization bug for hourly interval training

### DIFF
--- a/examples/crypto_ensemble_forecast.py
+++ b/examples/crypto_ensemble_forecast.py
@@ -173,7 +173,16 @@ def train_ensemble_model(symbol, period, lookback, forecast_horizon, epochs, foc
     # Otherwise, with crypto going from $40k→$106k, the historical mean ($70k) causes
     # the model to predict values that look like huge drops from current levels
     scaler = StandardScaler()
-    recent_window = min(90, len(data) // 2)  # Last 90 days or half the data
+
+    # Calculate recent_window based on interval to get ~90 days worth of data
+    if interval == '1h':
+        # For hourly data: 90 days * 24 hours = 2160 hours
+        recent_days_in_hours = 90 * 24
+        recent_window = min(recent_days_in_hours, len(data) // 2)
+    else:
+        # For daily data: 90 days = 90 samples
+        recent_window = min(90, len(data) // 2)
+
     scaler.fit(data[-recent_window:])  # Fit on recent data only
     data_normalized = scaler.transform(data)  # Transform all data with recent scaler
 


### PR DESCRIPTION
## Summary
- Fixed NaN loss issue when training models on hourly (1h) interval data
- Corrected scaler fitting window calculation to account for interval type
- Ensures consistent 90-day normalization period across all intervals

## Problem
The scaler fitting window used a fixed 90 sample count regardless of interval:
```python
recent_window = min(90, len(data) // 2)  # Last 90 days or half the data
```

For hourly data with 522k samples, this meant using only the last **90 HOURS** (3.75 days) to fit the scaler instead of **90 DAYS** worth of data (2160 hours).

This caused:
1. Severe under-sampling for normalization
2. Improper scaling of data
3. Massive initial loss values (11670759)
4. Gradient explosion
5. NaN losses starting from epoch 2
6. All predictions becoming NaN

## Solution
Calculate `recent_window` based on interval type:
```python
if interval == '1h':
    # For hourly data: 90 days * 24 hours = 2160 hours
    recent_days_in_hours = 90 * 24
    recent_window = min(recent_days_in_hours, len(data) // 2)
else:
    # For daily data: 90 days = 90 samples
    recent_window = min(90, len(data) // 2)
```

This ensures the scaler is fitted on the same **time period** (90 days) regardless of data interval, maintaining proper normalization and preventing NaN explosions.

## Impact
- Fixes training failures on b200 runpod for hourly analysis
- Enables proper hourly interval forecasting
- Maintains existing daily interval behavior

## Files Changed
- `examples/crypto_ensemble_forecast.py`: Added interval-aware recent_window calculation

## Testing
Reported issue showed NaN training losses on b200 runpod. This fix addresses the root cause by ensuring proper normalization window for hourly data.