### PR TITLE
Fix missing 'name' field in paper trading API call from Auto-Optimize

### DIFF
--- a/frontend/src/pages/AutoOptimizePage.jsx
+++ b/frontend/src/pages/AutoOptimizePage.jsx
@@ -164,6 +164,7 @@ export default function AutoOptimizePage() {
 
     try {
       const request = {
+        name: `Auto-Optimized ${config.symbol} (${new Date().toLocaleDateString()})`,
         config: {
           symbol: config.symbol,
           initial_capital: config.initial_capital,


### PR DESCRIPTION
## Summary
- Fixed a bug where applying auto-optimization results to paper trading would fail with a 400 error
- The frontend was only sending a `config` object, but the backend API requires both `name` and `config` fields
- Added a descriptive name field formatted as: `Auto-Optimized {SYMBOL} ({DATE})`

## Changes
- Modified `frontend/src/pages/AutoOptimizePage.jsx` in the `applyOptimalParameters` function
- Added the missing `name` field to the request payload

## Test plan
- Run an auto-optimization workflow
- Click "Apply to Paper Trading" button
- Verify that a new paper trading session is created successfully
- Check that the session name includes the symbol and date