### PR TITLE
Enhance auto-optimizer results display and add threshold parameters to backtest UI

### DIFF
--- a/frontend/src/pages/AutoOptimizePage.jsx
+++ b/frontend/src/pages/AutoOptimizePage.jsx
@@ -396,7 +396,7 @@ export default function AutoOptimizePage() {
                             <div className="flex justify-between">
                               <span className="text-gray-400">Return:</span>
                               <span className="text-blue-400 font-mono">
-                                {stageResult.best_metrics?.total_return_pct?.toFixed(1) || 'N/A'}%
+                                {stageResult.best_metrics?.total_return ? (stageResult.best_metrics.total_return * 100).toFixed(1) : 'N/A'}%
                               </span>
                             </div>
                           </div>
@@ -474,7 +474,7 @@ export default function AutoOptimizePage() {
               <div className="bg-gray-800/50 rounded-lg p-4">
                 <div className="text-sm text-gray-400 mb-1">Total Return</div>
                 <div className="text-2xl font-bold text-blue-400">
-                  {autoOptimizeRun.optimal_metrics?.total_return_pct?.toFixed(1) || 'N/A'}%
+                  {autoOptimizeRun.optimal_metrics?.total_return ? (autoOptimizeRun.optimal_metrics.total_return * 100).toFixed(1) : 'N/A'}%
                 </div>
               </div>
 
@@ -513,8 +513,49 @@ export default function AutoOptimizePage() {
                     {autoOptimizeRun.optimal_params?.buy_threshold || 'N/A'}
                   </span>
                 </div>
+                <div>
+                  <span className="text-gray-400">Moderate Buy:</span>{' '}
+                  <span className="text-gray-100 font-mono">
+                    {autoOptimizeRun.optimal_params?.moderate_buy_threshold || 'N/A'}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-gray-400">Sell:</span>{' '}
+                  <span className="text-gray-100 font-mono">
+                    {autoOptimizeRun.optimal_params?.sell_threshold || 'N/A'}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-gray-400">Moderate Sell:</span>{' '}
+                  <span className="text-gray-100 font-mono">
+                    {autoOptimizeRun.optimal_params?.moderate_sell_threshold || 'N/A'}
+                  </span>
+                </div>
               </div>
             </div>
+
+            {/* Selected Strategies */}
+            {autoOptimizeRun.stages?.[2]?.optimization_id && (
+              <div className="bg-gray-800 rounded-lg p-4 mb-4">
+                <h3 className="font-semibold text-gray-100 mb-3">Selected Strategies (Top 3)</h3>
+                <div className="flex flex-wrap gap-2">
+                  {autoOptimizeRun.stages[2].optimization_id.split(',').map((strategy, idx) => (
+                    <span
+                      key={idx}
+                      className="px-3 py-1.5 bg-brand-900/30 text-brand-400 border border-brand-700 rounded-lg text-sm font-medium"
+                    >
+                      {idx === 0 && '🥇 '}
+                      {idx === 1 && '🥈 '}
+                      {idx === 2 && '🥉 '}
+                      {strategy.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                    </span>
+                  ))}
+                </div>
+                <p className="text-xs text-gray-400 mt-2">
+                  These strategies performed best during Stage 3: Strategy Selection
+                </p>
+              </div>
+            )}
 
             <button
               onClick={applyOptimalParameters}

--- a/frontend/src/pages/BacktestPage.jsx
+++ b/frontend/src/pages/BacktestPage.jsx
@@ -24,6 +24,11 @@ export default function BacktestPage() {
     initial_capital: 100000,
     position_size_pct: 10,
     min_edge_bps: 55,
+    strong_buy_threshold: 0.80,
+    buy_threshold: 0.60,
+    moderate_buy_threshold: 0.50,
+    sell_threshold: 0.60,
+    moderate_sell_threshold: 0.50,
     walk_forward_enabled: true,
     train_window_days: 252,
     test_window_days: 63,
@@ -63,6 +68,15 @@ export default function BacktestPage() {
       initial_capital: parseFloat(formData.initial_capital),
       position_size_pct: parseFloat(formData.position_size_pct),
       min_edge_bps: parseFloat(formData.min_edge_bps),
+      optimizable: {
+        position_size_pct: parseFloat(formData.position_size_pct),
+        min_edge_bps: parseFloat(formData.min_edge_bps),
+        strong_buy_threshold: parseFloat(formData.strong_buy_threshold),
+        buy_threshold: parseFloat(formData.buy_threshold),
+        moderate_buy_threshold: parseFloat(formData.moderate_buy_threshold),
+        sell_threshold: parseFloat(formData.sell_threshold),
+        moderate_sell_threshold: parseFloat(formData.moderate_sell_threshold),
+      },
       inference_mode: formData.inference_mode,
       transaction_costs: {
         taker_fee_bps: 5.0,
@@ -411,6 +425,97 @@ export default function BacktestPage() {
                   <p className="text-xs text-gray-400 mt-1">
                     Minimum predicted move to execute trade (default: 55 bps = 3x transaction costs)
                   </p>
+                </div>
+              </div>
+
+              {/* Consensus Thresholds */}
+              <div className="space-y-3">
+                <h4 className="text-sm font-semibold text-gray-300">Consensus Thresholds</h4>
+                <p className="text-xs text-gray-400">
+                  Define what % of strategies must agree to trigger different signal strengths
+                </p>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-300 mb-1">
+                      Strong Buy Threshold
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={formData.strong_buy_threshold}
+                      onChange={(e) => setFormData({ ...formData, strong_buy_threshold: e.target.value })}
+                      className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 text-sm"
+                      required
+                    />
+                    <p className="text-xs text-gray-500 mt-0.5">≥{(formData.strong_buy_threshold * 100).toFixed(0)}% bullish</p>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-300 mb-1">
+                      Buy Threshold
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={formData.buy_threshold}
+                      onChange={(e) => setFormData({ ...formData, buy_threshold: e.target.value })}
+                      className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 text-sm"
+                      required
+                    />
+                    <p className="text-xs text-gray-500 mt-0.5">≥{(formData.buy_threshold * 100).toFixed(0)}% bullish</p>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-300 mb-1">
+                      Moderate Buy Threshold
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={formData.moderate_buy_threshold}
+                      onChange={(e) => setFormData({ ...formData, moderate_buy_threshold: e.target.value })}
+                      className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 text-sm"
+                      required
+                    />
+                    <p className="text-xs text-gray-500 mt-0.5">≥{(formData.moderate_buy_threshold * 100).toFixed(0)}% bullish</p>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-300 mb-1">
+                      Sell Threshold
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={formData.sell_threshold}
+                      onChange={(e) => setFormData({ ...formData, sell_threshold: e.target.value })}
+                      className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 text-sm"
+                      required
+                    />
+                    <p className="text-xs text-gray-500 mt-0.5">≥{(formData.sell_threshold * 100).toFixed(0)}% bearish</p>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-300 mb-1">
+                      Moderate Sell Threshold
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="1"
+                      value={formData.moderate_sell_threshold}
+                      onChange={(e) => setFormData({ ...formData, moderate_sell_threshold: e.target.value })}
+                      className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-gray-100 text-sm"
+                      required
+                    />
+                    <p className="text-xs text-gray-500 mt-0.5">≥{(formData.moderate_sell_threshold * 100).toFixed(0)}% bearish</p>
+                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
Fixes two major issues with the auto-optimizer and enhances the backtest UI:

### Auto-Optimizer Improvements
- **Fixed total return showing N/A**: Backend returns `total_return` as decimal (0.25 = 25%), but UI was looking for non-existent `total_return_pct` field
- **Added strategy selection visibility**: Auto-optimizer Stage 3 selects top 3 best-performing strategies, but this was hidden from users
- **Complete parameter display**: Now shows all 7 optimized parameters (was only showing 4)

### Backtest UI Improvements
- **Added consensus threshold controls**: New section with 5 threshold parameter inputs (strong_buy, buy, moderate_buy, sell, moderate_sell)
- **Full parameter parity**: Can now create backtests with exact same parameters as auto-optimizer finds

## Changes

### AutoOptimizePage.jsx
1. Fixed `total_return_pct` → `total_return * 100` conversion (2 locations)
2. Added moderate_buy_threshold, sell_threshold, moderate_sell_threshold to optimal parameters display
3. Added new "Selected Strategies (Top 3)" section showing winning strategies with medals (🥇🥈🥉)
4. Strategies pulled from `stages[2].optimization_id` (Stage 3: Strategy Selection)

### BacktestPage.jsx
1. Added 5 threshold parameters to form state with defaults
2. Added "Consensus Thresholds" UI section with input fields
3. Updated config construction to include `optimizable` object with all 7 parameters
4. Maintains backward compatibility with legacy `position_size_pct` and `min_edge_bps` fields

## Technical Details

**Auto-Optimizer Stage 3 (Strategy Selection)**:
- Tests each enabled strategy individually
- Ranks by Sharpe ratio
- Selects top 3 performers
- Uses only those 3 in Stage 4 fine-tuning
- Stores results in `stage_result.optimization_id` as comma-separated string

**Backend Models**:
- `BacktestConfig.optimizable: OptimizableParams` contains all 7 threshold parameters
- `BacktestMetrics.total_return` is a float (0.25 for 25%)
- Frontend now correctly converts: `total_return * 100`

## Test Plan
- [x] Auto-optimizer displays total return percentage correctly
- [x] Auto-optimizer shows top 3 selected strategies with medals
- [x] Auto-optimizer shows all 7 optimized parameters
- [x] Backtest form includes all 5 threshold inputs
- [x] Backtest creation sends `optimizable` object to backend
- [x] Can apply auto-optimizer results to both paper trading and backtesting